### PR TITLE
Fixes #2 - disable linting on removed code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
+// retain all original lines for numbering, but disable eslint so as to not trigger rules such as no-multiple-empty-lines and others
 var generateReplacement = function (lines) {
-  var str = '{', i = 1;
+  var str = '{/* eslint-disable */ ', i = 1;
 
   for (;i < lines; i++) str += '\n';
-  return str += '}';
+  return str += '}/* eslint-enable */';
 }
+
 
 var Plugin = {
   preprocess: function(text) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // retain all original lines for numbering, but disable eslint so as to not trigger rules such as no-multiple-empty-lines and others
 var generateReplacement = function (lines) {
-  var str = '{/* eslint-disable */ ', i = 1;
+  var str = '/* eslint-disable */{', i = 1;
 
   for (;i < lines; i++) str += '\n';
   return str += '}/* eslint-enable */';

--- a/test/data/sample.jsx
+++ b/test/data/sample.jsx
@@ -1,0 +1,51 @@
+const styles = (<style>
+  html {
+  font-family: Roboto, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  body {
+  font-size: 15px;
+    line-height: 24px;
+  }
+
+  body, h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+  }
+
+  a {
+  color: #333;
+    text-decoration: none;
+  }
+
+  a:hover {
+  text-decoration: underline;
+  }
+</style>)
+
+let x = 1;
+
+const styles2 = (<style>
+  html {
+  font-family: Roboto, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  body {
+  font-size: 15px;
+    line-height: 24px;
+  }
+
+  body, h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+  }
+
+  a {
+  color: #333;
+    text-decoration: none;
+  }
+
+  a:hover {
+  text-decoration: underline;
+  }
+</style>)

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -52,6 +52,13 @@ var cases = [
 
 linter.addPlugin("eslint-plugin-cssx", CSSXPlugin);
 
+it('should give newline result', function () {
+  var text = fs.readFileSync(__dirname + '/data/sample.jsx').toString('utf8')
+  expect(text).to.be.ok
+  var result = CSSXPlugin.processors['.jsx'].preprocess(text)
+  expect(result[0]).to.equal('const styles = ({/* eslint-disable */ \n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n}/* eslint-enable */)\n\nlet x = 1;\n\nconst styles2 = ({/* eslint-disable */ \n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n}/* eslint-enable */)')
+});
+
 describe('Given the eslint-plugin-cssx', function () {
   cases.forEach(function (testCase) {
     if (testCase.skip) return;

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -56,7 +56,7 @@ it('should give newline result', function () {
   var text = fs.readFileSync(__dirname + '/data/sample.jsx').toString('utf8')
   expect(text).to.be.ok
   var result = CSSXPlugin.processors['.jsx'].preprocess(text)
-  expect(result[0]).to.equal('const styles = ({/* eslint-disable */ \n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n}/* eslint-enable */)\n\nlet x = 1;\n\nconst styles2 = ({/* eslint-disable */ \n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n}/* eslint-enable */)')
+  expect(result[0]).to.equal('const styles = (/* eslint-disable */{\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n}/* eslint-enable */)\n\nlet x = 1;\n\nconst styles2 = (/* eslint-disable */{\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n}/* eslint-enable */)')
 });
 
 describe('Given the eslint-plugin-cssx', function () {


### PR DESCRIPTION
It makes sense to keep the newlines instead of doing a multi-line replacement as I suggested in #2.  This will just disable linting over the removed code to disable false positives.

If you could merge and push a version, I would appreciate it!
